### PR TITLE
Add a way for Ancestry to invalidate it's result cache based on the given task and it's signature set

### DIFF
--- a/ancestry/ancestry.py
+++ b/ancestry/ancestry.py
@@ -68,8 +68,12 @@ class Ancestry(ServiceBase):
 
     def get_tool_version(self):
         # Cache invalidation should be based on the task given and the signature patterns
-        ancestry_hash = sha256(str(self._task.temp_submission_data.get("ancestry", [])).encode()).hexdigest()
-        return f'{ancestry_hash}.r{self.signature_hash}'
+        if not self._task:
+            # Return default tool version if no task is set (only applicable at initialization)
+            return super().get_tool_version()
+        else:
+            ancestry_hash = sha256(str(self._task.temp_submission_data.get("ancestry", [])).encode()).hexdigest()
+            return f'{ancestry_hash}.r{self.signature_hash}'
 
     def execute(self, request: ServiceRequest) -> None:
         result = Result()

--- a/ancestry/ancestry.py
+++ b/ancestry/ancestry.py
@@ -1,12 +1,14 @@
 import re
+from hashlib import sha256
 from typing import Dict, List
 
-from ancestry.icon_map import AL_TYPE_ICON
 from assemblyline.common.uid import SHORT, get_id_from_data
 from assemblyline_v4_service.common.base import ServiceBase
 from assemblyline_v4_service.common.request import ServiceRequest
 from assemblyline_v4_service.common.result import Heuristic, Result, ResultTimelineSection
 from assemblyline_v4_service.common.task import PARENT_RELATION
+
+from ancestry.icon_map import AL_TYPE_ICON
 
 
 class AncestrySignature:
@@ -62,6 +64,12 @@ class AncestryNode(object):
 class Ancestry(ServiceBase):
     def __init__(self, config) -> None:
         super().__init__(config)
+        self.signature_hash = sha256(str(self.config.get("signatures", {})).encode()).hexdigest()
+
+    def get_tool_version(self):
+        # Cache invalidation should be based on the task given and the signature patterns
+        ancestry_hash = sha256(str(self._task.temp_submission_data.get("ancestry", [])).encode()).hexdigest()
+        return f'{ancestry_hash}.r{self.signature_hash}'
 
     def execute(self, request: ServiceRequest) -> None:
         result = Result()

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -9,7 +9,6 @@ category: Static Analysis
 
 file_required: false
 timeout: 60
-disable_cache: true
 privileged: true
 
 enabled: true


### PR DESCRIPTION
Related to: https://cccs.atlassian.net/browse/AL-4059